### PR TITLE
Update qfieldcloud-cli to catch up the new server APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,14 @@ Environment variables can be used instead of passing some common global options.
   list-projects     List QFieldCloud projects.
   list-files        List QFieldCloud project files.
   create-project    Creates a new empty QFieldCloud project.
+  delete-project    Deletes a QFieldCloud project.
   upload-files      Upload files to a QFieldCloud project.
   download-files    Download QFieldCloud project files.
-  package-trigger   Initiate project packaging for QField.
-  package-status    Check project packaging status.
+  delete-files      Delete QFieldCloud project files.
+  list-jobs         List project jobs.
+  job-trigger       Triggers a new job.
+  job-status        Get job status.
+  package-latest    Check project packaging status.
   package-download  Download packaged QFieldCloud project files.
 ```
 
@@ -135,6 +139,14 @@ Options:
   --is-public / --is-private  Mark the project as public.
 ```
 
+#### delete-project
+
+Deletes a QFieldCloud project.
+
+```
+qfieldcloud-cli delete-project [OPTIONS] PROJECT_ID
+```
+
 #### upload-files
 
 Upload files to a QFieldCloud project.
@@ -165,6 +177,58 @@ Options:
                                   downloading the rest. Default: False
 ```
 
+#### delete-files
+
+Delete QFieldCloud project files.
+
+```
+qfieldcloud-cli delete-files [OPTIONS] PROJECT_ID PATHS...
+
+Options:
+  --exit-on-error / --no-exit-on-error
+                                  If any project file delete operations fails
+                                  stop, stop deleting the rest. Default: False
+```
+
+#### job-list
+
+List project jobs.
+
+```
+qfieldcloud-cli list-jobs [OPTIONS] PROJECT_ID
+
+Options:
+  --type JOBTYPES  Job type. One of package, delta_apply or
+                   process_projectfile.
+```
+
+#### job-trigger
+
+Triggers a new job.
+
+```
+qfieldcloud-cli job-trigger [OPTIONS] PROJECT_ID JOB_TYPE
+
+Options:
+  --force / --no-force  Should force creating a new job. Default: False
+```
+
+#### job-status
+
+Get job status.
+
+```
+qfieldcloud-cli job-status [OPTIONS] JOB_ID
+```
+
+#### package-latest
+
+Check project packaging status.
+
+```
+qfieldcloud-cli package-latest [OPTIONS] PROJECT_ID
+```
+
 #### package-download
 
 Download packaged QFieldCloud project files.
@@ -178,22 +242,6 @@ Options:
   --exit-on-error / --no-exit-on-error
                                   If any packaged file downloads fails stop
                                   downloading the rest. Default: False
-```
-
-#### package-trigger
-
-Initiate project packaging for QField.
-
-```
-qfieldcloud-cli package-trigger PROJECT_ID
-```
-
-#### package-status
-
-Check project packaging status.
-
-```
-qfieldcloud-cli package-status PROJECT_ID
 ```
 
 ## Development

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setuptools.setup(
     install_requires=[
         "click>=8",
         "requests>=2.0",
+        "tqdm==4.62.3",
     ],
     package_dir={"": "src"},
     packages=setuptools.find_packages(where="src"),

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -251,7 +251,7 @@ def download_files(ctx, project_id, local_dir, filter_glob, exit_on_error):
             return
 
         if file.get("error"):
-            print(f'File "{file["name"]}" failed to download.')
+            print(f'File "{file["name"]}" failed to download:\n{file["error"]}')
         else:
             print(f'File "{file["name"]}" has been downloaded successfully.')
 

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -306,7 +306,25 @@ def download_files(ctx, project_id, local_dir, filter_glob, exit_on_error):
 
 @cli.command()
 @click.argument("project_id")
-@click.option("--type", "job_type", type=sdk.JobTypes)
+@click.argument("paths", nargs=-1, required=True)
+@click.option(
+    "--exit-on-error/--no-exit-on-error",
+    help="If any project file delete operations fails stop, stop deleting the rest. Default: False",
+)
+@click.pass_context
+def delete_files(ctx, project_id, paths, exit_on_error):
+    """Delete QFieldCloud project files."""
+
+    log(f'Deleting project "{project_id}" files…')
+
+    paths_result = ctx.obj["client"].delete_files(project_id, paths, exit_on_error)
+
+    if ctx.obj["format_json"]:
+        print_json(paths_result)
+
+@cli.command()
+@click.argument("project_id")
+@click.option("--type", "job_type", type=sdk.JobTypes, help="Job type. One of package, delta_apply or process_projectfile.")
 @click.pass_context
 def list_jobs(ctx, project_id, job_type):
     """List project jobs."""
@@ -331,7 +349,7 @@ def list_jobs(ctx, project_id, job_type):
 )
 @click.pass_context
 def job_trigger(ctx, project_id, job_type, force):
-    """Initiate a new job."""
+    """Triggers a new job."""
 
     log(f'Triggering "{job_type}" job for project "{project_id}"…')
 
@@ -358,24 +376,6 @@ def job_status(ctx, job_id):
     else:
         log(f'Job status for {job_id}: {status["status"]}')
 
-
-@cli.command()
-@click.argument("project_id")
-@click.argument("paths", nargs=-1, required=True)
-@click.option(
-    "--exit-on-error/--no-exit-on-error",
-    help="If any project file delete operations fails stop, stop deleting the rest. Default: False",
-)
-@click.pass_context
-def delete_files(ctx, project_id, paths, exit_on_error):
-    """Delete QFieldCloud project files."""
-
-    log(f'Deleting project "{project_id}" files…')
-
-    paths_result = ctx.obj["client"].delete_files(project_id, paths, exit_on_error)
-
-    if ctx.obj["format_json"]:
-        print_json(paths_result)
 
 @cli.command()
 @click.argument("project_id")

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -209,6 +209,23 @@ def create_project(ctx, name, owner, description, is_public):
 
 @cli.command()
 @click.argument("project_id")
+@click.pass_context
+def delete_project(ctx, project_id):
+    """Deletes a QFieldCloud project."""
+
+    log(f'Deleting project "{project_id}"…')
+
+    payload = ctx.obj["client"].delete_project(project_id)
+
+    if ctx.obj["format_json"]:
+        # print_json(payload)
+        print(payload, payload.content)
+    else:
+        log(f'Delеted project "{project_id}".')
+
+
+@cli.command()
+@click.argument("project_id")
 @click.argument("project_path")
 @click.option(
     "--filter",

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -246,17 +246,9 @@ def upload_files(ctx, project_id, project_path, filter_glob, exit_on_error):
 def download_files(ctx, project_id, local_dir, filter_glob, exit_on_error):
     """Download QFieldCloud project files."""
 
-    def downloaded_cb(file):
-        if ctx.obj["format_json"]:
-            return
-
-        if file.get("error"):
-            print(f'File "{file["name"]}" failed to download:\n{file["error"]}')
-        else:
-            print(f'File "{file["name"]}" has been downloaded successfully.')
 
     files = ctx.obj["client"].download_files(
-        project_id, local_dir, filter_glob, exit_on_error, finished_cb=downloaded_cb
+        project_id, local_dir, filter_glob, exit_on_error
     )
 
     if ctx.obj["format_json"]:
@@ -408,17 +400,8 @@ def package_latest(ctx, project_id):
 def package_download(ctx, project_id, local_dir, filter_glob, exit_on_error):
     """Download packaged QFieldCloud project files."""
 
-    def downloaded_cb(file):
-        if ctx.obj["format_json"]:
-            return
-
-        if file.get("error"):
-            print(f'Packaged file "{file["name"]}" failed to download.')
-        else:
-            print(f'Packaged file "{file["name"]}" has been downloaded successfully.')
-
     files = ctx.obj["client"].package_download(
-        project_id, local_dir, filter_glob, exit_on_error, finished_cb=downloaded_cb
+        project_id, local_dir, filter_glob, exit_on_error
     )
 
     if ctx.obj["format_json"]:

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -356,20 +356,7 @@ def job_status(ctx, job_id):
     if ctx.obj["format_json"]:
         print_json(status)
     else:
-        if status["type"] == sdk.JobType.PackageJob.value:
-            log(f'Packaging status for {job_id}: {status["status"]}')
-
-            for layer_obj in status["layers"].values():
-                if layer_obj["valid"]:
-                    log(
-                        f'Layer "{layer_obj["name"]}" is valid, finished with status: {layer_obj["status"]}'
-                    )
-                else:
-                    log(
-                        f'Invalid layer "{layer_obj["name"]}", status: {layer_obj["status"]}'
-                    )
-        else:
-            log(f'Job status for {job_id}: {status["status"]}')
+        log(f'Job status for {job_id}: {status["status"]}')
 
 
 @cli.command()

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -195,6 +195,9 @@ def list_files(ctx, project_id):
 @click.pass_context
 def create_project(ctx, name, owner, description, is_public):
     """Creates a new empty QFieldCloud project."""
+
+    log("Creating project {}…".format(f"{owner}/{name}" if owner else name))
+
     project = ctx.obj["client"].create_project(
         name, owner, description=description, is_public=is_public
     )
@@ -239,6 +242,8 @@ def delete_project(ctx, project_id):
 @click.pass_context
 def upload_files(ctx, project_id, project_path, filter_glob, exit_on_error):
     """Upload files to a QFieldCloud project."""
+
+    log(f'Uploading files "{project_id}" from {project_path}…')
 
     files = ctx.obj["client"].upload_files(
         project_id, project_path, filter_glob, exit_on_error, show_progress=True,
@@ -305,6 +310,9 @@ def download_files(ctx, project_id, local_dir, filter_glob, exit_on_error):
 @click.pass_context
 def list_jobs(ctx, project_id, job_type):
     """List project jobs."""
+
+    log(f'Listing project "{project_id}" jobs…')
+
     status = ctx.obj["client"].list_jobs(project_id, job_type)
 
     if ctx.obj["format_json"]:
@@ -324,6 +332,9 @@ def list_jobs(ctx, project_id, job_type):
 @click.pass_context
 def job_trigger(ctx, project_id, job_type, force):
     """Initiate a new job."""
+
+    log(f'Triggering "{job_type}" job for project "{project_id}"…')
+
     status = ctx.obj["client"].job_trigger(project_id, job_type, force)
 
     if ctx.obj["format_json"]:
@@ -336,7 +347,10 @@ def job_trigger(ctx, project_id, job_type, force):
 @click.argument("job_id")
 @click.pass_context
 def job_status(ctx, job_id):
-    """Initiate a new job."""
+    """Get job status."""
+
+    log(f'Getting job "{job_id}" status…')
+
     status = ctx.obj["client"].job_status(job_id)
 
     if ctx.obj["format_json"]:
@@ -369,6 +383,8 @@ def job_status(ctx, job_id):
 def delete_files(ctx, project_id, paths, exit_on_error):
     """Delete QFieldCloud project files."""
 
+    log(f'Deleting project "{project_id}" files…')
+
     paths_result = ctx.obj["client"].delete_files(project_id, paths, exit_on_error)
 
     if ctx.obj["format_json"]:
@@ -379,6 +395,9 @@ def delete_files(ctx, project_id, paths, exit_on_error):
 @click.pass_context
 def package_latest(ctx, project_id):
     """Check project packaging status."""
+
+    log(f'Getting the latest project "{project_id}" package info…')
+
     status = ctx.obj["client"].package_latest(project_id)
 
     if ctx.obj["format_json"]:
@@ -417,6 +436,8 @@ def package_latest(ctx, project_id):
 @click.pass_context
 def package_download(ctx, project_id, local_dir, filter_glob, exit_on_error):
     """Download packaged QFieldCloud project files."""
+
+    log(f'Downloading the latest project "{project_id}" package files to {local_dir}…')
 
     files = ctx.obj["client"].package_download(
         project_id, local_dir, filter_glob, exit_on_error, show_progress=True

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -3,6 +3,7 @@
 import collections
 import json
 from enum import Enum
+import sys
 
 import click
 
@@ -19,6 +20,8 @@ class OutputFormat(Enum):
 def print_json(data):
     print(json.dumps(data, sort_keys=True, indent=2))
 
+def log(*msgs):
+    print(*msgs, file=sys.stderr)
 
 class OrderedGroup(click.Group):
     def __init__(self, name=None, commands=None, **attrs):
@@ -101,18 +104,21 @@ def cli(
 @click.pass_context
 def login(ctx, username, password) -> None:
     """Login to QFieldCloud."""
+
+    log(f"Log in {username}…")
+
     user_data = ctx.obj["client"].login(username, password)
 
     if ctx.obj["format_json"]:
         print_json(user_data)
     else:
-        print(f'Welcome to QFieldCloud, {user_data["username"]}.')
-        print(
+        log(f'Welcome to QFieldCloud, {user_data["username"]}.')
+        log(
             "QFieldCloud has generated a secret token to identify you. "
             "Put the token in your in the environment using the following code, "
             "so you do not need to write your username and password again:"
         )
-        print(f'export QFIELDCLOUD_TOKEN="{user_data["token"]}"')
+        log(f'export QFIELDCLOUD_TOKEN="{user_data["token"]}"')
 
 
 @cli.command()
@@ -120,12 +126,14 @@ def login(ctx, username, password) -> None:
 def logout(ctx):
     """Logout and expire the token."""
 
+    log(f'Log out…')
+
     payload = ctx.obj["client"].logout()
 
     if ctx.obj["format_json"]:
         print_json(payload)
     else:
-        print(payload["detail"])
+        log(payload["detail"])
 
 
 @cli.command()
@@ -137,6 +145,9 @@ def logout(ctx):
 @click.pass_context
 def list_projects(ctx, include_public):
     """List QFieldCloud projects."""
+
+    log("Listing projects…")
+
     projects = ctx.obj["client"].list_projects(
         include_public=include_public,
     )
@@ -145,11 +156,11 @@ def list_projects(ctx, include_public):
         print_json(projects)
     else:
         if projects:
-            print("Projects:")
+            log("Projects:")
             for project in projects:
-                print(f'{project["id"]}\t{project["owner"]}/{project["name"]}')
+                log(f'{project["id"]}\t{project["owner"]}/{project["name"]}')
         else:
-            print("User does not have any projects yet.")
+            log("User does not have any projects yet.")
 
 
 @cli.command()
@@ -157,17 +168,20 @@ def list_projects(ctx, include_public):
 @click.pass_context
 def list_files(ctx, project_id):
     """List QFieldCloud project files."""
+
+    log(f'Getting file list for "{project_id}"…')
+
     files = ctx.obj["client"].list_files(project_id)
 
     if ctx.obj["format_json"]:
         print_json(files)
     else:
         if files:
-            print(f'Files for project "{project_id}":')
+            log(f'Files for project "{project_id}":')
             for file in files:
-                print(f'{file["last_modified"]}\t{file["name"]}')
+                log(f'{file["last_modified"]}\t{file["name"]}')
         else:
-            print(f'No files within project "{project_id}"')
+            log(f'No files within project "{project_id}"')
 
 
 @cli.command()
@@ -187,7 +201,7 @@ def create_project(ctx, name, owner, description, is_public):
     if ctx.obj["format_json"]:
         print_json(project)
     else:
-        print(
+        log(
             f'Created project "{project["owner"]}/{project["name"]}" with project id "{project["id"]}".'
         )
 
@@ -213,9 +227,9 @@ def upload_files(ctx, project_id, project_path, filter_glob, exit_on_error):
             return
 
         if file.get("error"):
-            print(f'File "{file["name"]}" failed to upload.')
+            log(f'File "{file["name"]}" failed to upload.')
         else:
-            print(f'File "{file["name"]}" has been uploaded successfully.')
+            log(f'File "{file["name"]}" has been uploaded successfully.')
 
     files = ctx.obj["client"].upload_files(
         project_id, project_path, filter_glob, exit_on_error, cb=upload_cb
@@ -225,9 +239,9 @@ def upload_files(ctx, project_id, project_path, filter_glob, exit_on_error):
         print_json(files)
     else:
         if files:
-            print(f"Upload finished after uploading {len(files)}.")
+            log(f"Upload finished after uploading {len(files)}.")
         else:
-            print("Nothing to upload.")
+            log("Nothing to upload.")
 
 
 @cli.command()
@@ -246,6 +260,7 @@ def upload_files(ctx, project_id, project_path, filter_glob, exit_on_error):
 def download_files(ctx, project_id, local_dir, filter_glob, exit_on_error):
     """Download QFieldCloud project files."""
 
+    log(f'Downloading project "{project_id}" files to {local_dir}…')
 
     files = ctx.obj["client"].download_files(
         project_id, local_dir, filter_glob, exit_on_error
@@ -255,16 +270,21 @@ def download_files(ctx, project_id, local_dir, filter_glob, exit_on_error):
         print_json(files)
     else:
         if files:
-            print(f"Download status of files in project {project_id}:")
+            count = 0
             for file in files:
-                print(f'{file["status"].value}\t{file["name"]}')
+                if file["status"] == sdk.DownloadStatus.FAILED:
+                    log(f'{file["name"]} - failed to download.')
+                else:
+                    count += 1
+
+            log(f"Downloaded {count} file(s).")
         else:
             if filter_glob:
-                print(
+                log(
                     f"No files to download for project {project_id} at {filter_glob}"
                 )
             else:
-                print(f"No files to download for project {project_id}")
+                log(f"No files to download for project {project_id}")
 
 
 @cli.command()
@@ -278,7 +298,7 @@ def list_jobs(ctx, project_id, job_type):
     if ctx.obj["format_json"]:
         print_json(status)
     else:
-        print(f'Job of type "{job_type}" triggered for project "{project_id}": {status["id"]}.')
+        log(f'Job of type "{job_type}" triggered for project "{project_id}": {status["id"]}.')
 
 
 @cli.command()
@@ -297,7 +317,7 @@ def job_trigger(ctx, project_id, job_type, force):
     if ctx.obj["format_json"]:
         print_json(status)
     else:
-        print(f'Job of type "{job_type}" triggered for project "{project_id}": {status["id"]}.')
+        log(f'Job of type "{job_type}" triggered for project "{project_id}": {status["id"]}.')
 
 
 @cli.command()
@@ -311,19 +331,19 @@ def job_status(ctx, job_id):
         print_json(status)
     else:
         if status["type"] == sdk.JobType.PackageJob.value:
-            print(f'Packaging status for {job_id}: {status["status"]}')
+            log(f'Packaging status for {job_id}: {status["status"]}')
 
             for layer_obj in status["layers"].values():
                 if layer_obj["valid"]:
-                    print(
+                    log(
                         f'Layer "{layer_obj["name"]}" is valid, finished with status: {layer_obj["status"]}'
                     )
                 else:
-                    print(
+                    log(
                         f'Invalid layer "{layer_obj["name"]}", status: {layer_obj["status"]}'
                     )
         else:
-            print(f'Job status for {job_id}: {status["status"]}')
+            log(f'Job status for {job_id}: {status["status"]}')
 
 
 @cli.command()
@@ -353,7 +373,7 @@ def package_trigger(ctx, project_id):
     if ctx.obj["format_json"]:
         print_json(status)
     else:
-        print(f"Packaging triggered for {project_id}.")
+        log(f"Packaging triggered for {project_id}.")
 
 
 @cli.command()
@@ -366,20 +386,20 @@ def package_latest(ctx, project_id):
     if ctx.obj["format_json"]:
         print_json(status)
     else:
-        print(f'Packaging status for {project_id}: {status["status"]}')
+        log(f'Packaging status for {project_id}: {status["status"]}')
         if status["layers"] is None:
             if status["status"] == 'failed':
-                print("Packaging have never been triggered on this project. Please run:")
-                print(f"qfieldcloud-cli package-trigger {project_id}")
+                log("Packaging have never been triggered on this project. Please run:")
+                log(f"qfieldcloud-cli package-trigger {project_id}")
             return
 
         for layer_obj in status["layers"].values():
             if layer_obj["valid"]:
-                print(
+                log(
                     f'Layer "{layer_obj["name"]}" is valid, finished with status: {layer_obj["status"]}'
                 )
             else:
-                print(
+                log(
                     f'Invalid layer "{layer_obj["name"]}", status: {layer_obj["status"]}'
                 )
 
@@ -408,16 +428,16 @@ def package_download(ctx, project_id, local_dir, filter_glob, exit_on_error):
         print_json(files)
     else:
         if files:
-            print(f"Download status of packaged files in project {project_id}:")
+            log(f"Download status of packaged files in project {project_id}:")
             for file in files:
-                print(f'{file["status"].value}\t{file["name"]}')
+                log(f'{file["status"].value}\t{file["name"]}')
         else:
             if filter_glob:
-                print(
+                log(
                     f"No packaged files to download for project {project_id} at {filter_glob}"
                 )
             else:
-                print(f"No packaged files to download for project {project_id}")
+                log(f"No packaged files to download for project {project_id}")
 
 
 if __name__ == "__main__":

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -362,20 +362,6 @@ def delete_files(ctx, project_id, paths, exit_on_error):
     if ctx.obj["format_json"]:
         print_json(paths_result)
 
-
-@cli.command()
-@click.argument("project_id")
-@click.pass_context
-def package_trigger(ctx, project_id):
-    """Initiate project packaging for QField."""
-    status = ctx.obj["client"].package_trigger(project_id)
-
-    if ctx.obj["format_json"]:
-        print_json(status)
-    else:
-        log(f"Packaging triggered for {project_id}.")
-
-
 @cli.command()
 @click.argument("project_id")
 @click.pass_context

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -263,7 +263,7 @@ def download_files(ctx, project_id, local_dir, filter_glob, exit_on_error):
     log(f'Downloading project "{project_id}" files to {local_dir}…')
 
     files = ctx.obj["client"].download_files(
-        project_id, local_dir, filter_glob, exit_on_error
+        project_id, local_dir, filter_glob, exit_on_error, show_progress=True
     )
 
     if ctx.obj["format_json"]:
@@ -421,7 +421,7 @@ def package_download(ctx, project_id, local_dir, filter_glob, exit_on_error):
     """Download packaged QFieldCloud project files."""
 
     files = ctx.obj["client"].package_download(
-        project_id, local_dir, filter_glob, exit_on_error
+        project_id, local_dir, filter_glob, exit_on_error, show_progress=True
     )
 
     if ctx.obj["format_json"]:

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -68,7 +68,7 @@ class OrderedGroup(click.Group):
 @click.option(
     "--verify-ssl/--no-verify-ssl",
     "verify_ssl",
-    default=True,
+    default=None,
     help="Verify SSL. Default: True",
 )
 @click.version_option(sdk.__version__)

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -68,7 +68,8 @@ class OrderedGroup(click.Group):
 @click.option(
     "--verify-ssl/--no-verify-ssl",
     "verify_ssl",
-    default=None,
+    default=True,
+    envvar="QFIELDCLOUD_VERIFY_SSL",
     help="Verify SSL. Default: True",
 )
 @click.version_option(sdk.__version__)

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -376,17 +376,17 @@ def package_latest(ctx, project_id):
         if status["layers"] is None:
             if status["status"] == 'failed':
                 log("Packaging have never been triggered on this project. Please run:")
-                log(f"qfieldcloud-cli package-trigger {project_id}")
+                log(f"qfieldcloud-cli job-trigger {project_id} package")
             return
 
         for layer_obj in status["layers"].values():
-            if layer_obj["valid"]:
+            if layer_obj["is_valid"]:
                 log(
-                    f'Layer "{layer_obj["name"]}" is valid, finished with status: {layer_obj["status"]}'
+                    f'Layer "{layer_obj["name"]}" is valid, finished with status: {layer_obj["error_code"]}'
                 )
             else:
                 log(
-                    f'Invalid layer "{layer_obj["name"]}", status: {layer_obj["status"]}'
+                    f'Invalid layer "{layer_obj["name"]}", status: {layer_obj["error_code"]}'
                 )
 
 

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -240,17 +240,8 @@ def delete_project(ctx, project_id):
 def upload_files(ctx, project_id, project_path, filter_glob, exit_on_error):
     """Upload files to a QFieldCloud project."""
 
-    def upload_cb(file):
-        if ctx.obj["format_json"]:
-            return
-
-        if file.get("error"):
-            log(f'File "{file["name"]}" failed to upload.')
-        else:
-            log(f'File "{file["name"]}" has been uploaded successfully.')
-
     files = ctx.obj["client"].upload_files(
-        project_id, project_path, filter_glob, exit_on_error, cb=upload_cb
+        project_id, project_path, filter_glob, exit_on_error, show_progress=True,
     )
 
     if ctx.obj["format_json"]:
@@ -258,6 +249,9 @@ def upload_files(ctx, project_id, project_path, filter_glob, exit_on_error):
     else:
         if files:
             log(f"Upload finished after uploading {len(files)}.")
+            for file in files:
+                if file.get("error"):
+                    log(f'File "{file["name"]}" failed to upload: {file["error"]} .')
         else:
             log("Nothing to upload.")
 

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -336,6 +336,23 @@ def job_status(ctx, job_id):
 
 @cli.command()
 @click.argument("project_id")
+@click.argument("paths", nargs=-1, required=True)
+@click.option(
+    "--exit-on-error/--no-exit-on-error",
+    help="If any project file delete operations fails stop, stop deleting the rest. Default: False",
+)
+@click.pass_context
+def delete_files(ctx, project_id, paths, exit_on_error):
+    """Delete QFieldCloud project files."""
+
+    paths_result = ctx.obj["client"].delete_files(project_id, paths, exit_on_error)
+
+    if ctx.obj["format_json"]:
+        print_json(paths_result)
+
+
+@cli.command()
+@click.argument("project_id")
 @click.pass_context
 def package_trigger(ctx, project_id):
     """Initiate project packaging for QField."""

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -379,7 +379,7 @@ class Client:
 
     def package_latest(self, project_id: str) -> Dict[str, Any]:
         """Check project packaging status."""
-        resp = self._request("GET", f"packages/{project_id}/latest")
+        resp = self._request("GET", f"packages/{project_id}/latest/")
 
         return resp.json()
 
@@ -405,7 +405,7 @@ class Client:
                 "The project has not been successfully packaged yet. Please use `qfieldcloud-cli package-trigger {project_id}` first."
             )
 
-        resp = self._request("GET", f"qfield-files/{project_id}")
+        resp = self._request("GET", f"packages/{project_id}/latest/")
 
         return self._download_files(
             resp.json()["files"],

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -7,6 +7,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
+import urllib3
+
 if sys.version_info >= (3, 8):
     from importlib import metadata
 else:
@@ -84,6 +86,9 @@ class Client:
         self.url = url or os.environ.get("QFIELDCLOUD_URL", None)
         self.token = token or os.environ.get("QFIELDCLOUD_TOKEN", None)
         self.verify_ssl = verify_ssl
+
+        if not self.verify_ssl:
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         if not self.url:
             raise QfcException(
@@ -180,6 +185,9 @@ class Client:
         files: List[Dict[str, Any]] = []
         for path in Path(project_path).rglob(filter_glob):
             if not path.is_file():
+                continue
+
+            if str(path.relative_to(project_path)).startswith(".qfieldsync"):
                 continue
 
             files.append(

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -299,7 +299,6 @@ class Client:
 
         return resp.json()
 
-
     def delete_files(
         self,
         project_id: str,

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -85,9 +85,7 @@ class Client:
         If the `token` is not provided, uses `QFIELDCLOUD_TOKEN` from the environment."""
         self.url = url or os.environ.get("QFIELDCLOUD_URL", None)
         self.token = token or os.environ.get("QFIELDCLOUD_TOKEN", None)
-        self.verify_ssl = verify_ssl or bool(
-            int(os.environ.get("QFIELDCLOUD_VERIFY_SSL", "1"))
-        )
+        self.verify_ssl = verify_ssl
 
         if not self.verify_ssl:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -239,7 +239,7 @@ class Client:
         local_dir: str,
         filter_glob: str = None,
         continue_on_error: bool = False,
-        finished_cb: Callable = None,
+        show_progress: bool = False,
     ) -> List[Dict]:
         """Download the specified project files into the destination dir.
 
@@ -258,7 +258,7 @@ class Client:
             local_dir,
             filter_glob,
             continue_on_error,
-            finished_cb,
+            show_progress,
         )
 
     def list_jobs(self, project_id: str, job_type: JobTypes = None) -> Dict[str, Any]:
@@ -389,7 +389,7 @@ class Client:
         local_dir: str,
         filter_glob: str = None,
         continue_on_error: bool = False,
-        finished_cb: Callable = None,
+        show_progress: bool = False,
     ) -> List[Dict]:
         """Download the specified project packaged files into the destination dir.
 
@@ -414,7 +414,7 @@ class Client:
             local_dir,
             filter_glob,
             continue_on_error,
-            finished_cb,
+            show_progress,
         )
 
     def _download_files(
@@ -425,7 +425,7 @@ class Client:
         local_dir: str,
         filter_glob: str = None,
         continue_on_error: bool = False,
-        finished_cb: Callable = None,
+        show_progress: bool = False,
     ) -> List[Dict]:
         if not filter_glob:
             filter_glob = "*"
@@ -462,16 +462,14 @@ class Client:
                     continue
                 else:
                     raise err
-            finally:
-                if callable(finished_cb):
-                    finished_cb(file)
 
             if not local_file.parent.exists():
                 local_file.parent.mkdir(parents=True)
 
             with open(local_file, "wb") as f:
                 for chunk in resp.iter_content(chunk_size=8192):
-                    if chunk:  # filter out keep-alive new chunks
+                    # filter out keep-alive new chunks
+                    if chunk:
                         f.write(chunk)
 
         return files_to_download

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -175,9 +175,8 @@ class Client:
         # skip .qfieldsync directory
 
         if not filter_glob:
-            filter_glob = "**/*"
+            filter_glob = "*"
 
-        # PurePath(filter_glob).match(pattern)
         files: List[Dict[str, Any]] = []
         for path in Path(project_path).rglob(filter_glob):
             if not path.is_file():

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -467,10 +467,21 @@ class Client:
                 local_file.parent.mkdir(parents=True)
 
             with open(local_file, "wb") as f:
+                download_file = f
+                if show_progress:
+                    from tqdm import tqdm
+                    from tqdm.utils import CallbackIOWrapper
+
+                    content_length = int(resp.headers.get("content-length", 0))
+                    progress_bar = tqdm(
+                        total=content_length, unit_scale=True, desc=file["name"]
+                    )
+                    download_file = CallbackIOWrapper(progress_bar.update, f, "write")
+
                 for chunk in resp.iter_content(chunk_size=8192):
                     # filter out keep-alive new chunks
                     if chunk:
-                        f.write(chunk)
+                        download_file.write(chunk)
 
         return files_to_download
 

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -165,6 +165,11 @@ class Client:
 
         return resp.json()
 
+    def delete_project(self, project_id: str):
+        resp = self._request("DELETE", f"projects/{project_id}")
+
+        return resp
+
     def upload_files(
         self,
         project_id: str,

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -397,7 +397,7 @@ class Client:
             local_dir: destination directory where the files will be downloaded
             filter_glob: if specified, download only packaged files which match the glob, otherwise download all
         """
-        project_status = self.package_status(project_id)
+        project_status = self.package_latest(project_id)
 
         if project_status["status"] != "finished":
             raise QfcException(

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -77,7 +77,7 @@ class QfcRequestException(QfcException):
 
 class Client:
     def __init__(
-        self, url: str = None, verify_ssl: bool = True, token: str = None
+        self, url: str = None, verify_ssl: bool = None, token: str = None
     ) -> None:
         """Prepares a new client.
 
@@ -85,7 +85,9 @@ class Client:
         If the `token` is not provided, uses `QFIELDCLOUD_TOKEN` from the environment."""
         self.url = url or os.environ.get("QFIELDCLOUD_URL", None)
         self.token = token or os.environ.get("QFIELDCLOUD_TOKEN", None)
-        self.verify_ssl = verify_ssl
+        self.verify_ssl = verify_ssl or bool(
+            int(os.environ.get("QFIELDCLOUD_VERIFY_SSL", "1"))
+        )
 
         if not self.verify_ssl:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -63,7 +63,7 @@ class QfcRequestException(QfcException):
         except Exception:
             json_content = ""
 
-        self.reason = f'Requested "{response.url}" and got "{response.status_code} {response.reason}":\n{json_content or response.raw}'
+        self.reason = f'Requested "{response.url}" and got "{response.status_code} {response.reason}":\n{json_content or response.content}'
 
     def __str__(self):
 

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -428,7 +428,6 @@ class Client:
         for file in files:
             if fnmatch.fnmatch(file["name"], filter_glob):
                 file["status"] = DownloadStatus.PENDING
-                file["status_reason"] = ""
                 files_to_download.append(file)
 
         for file in files_to_download:
@@ -442,15 +441,15 @@ class Client:
                     stream=True,
                 )
                 file["status"] = DownloadStatus.SUCCESS
-            except Exception as err:
-                assert resp
+            except QfcRequestException as err:
+                resp = err.response
 
                 logging.info(
                     f"{resp.request.method} {resp.url} got HTTP {resp.status_code}"
                 )
 
                 file["status"] = DownloadStatus.FAILED
-                file["status_reason"] = {"status_code": resp.status_code}
+                file["error"] = err
 
                 if continue_on_error:
                     continue


### PR DESCRIPTION
- Added `delete-project` command
- Added `delete-files` command
- Added `list-jobs` command
- Added `job-trigger` command
- Added `job-status` command
- Added `package-latest` command
- Removed `package-status` command, use `job-status` instead
- Removed `package-trigger` command, use `job-trigger` instead
- Removed the `finish_cb` for downloading/uploading, it never worked as intended
- Improvements in error handling when dowloading files
- Added progressbar when downloading/uploading a project
- Improved logs
- Improved docs
- If `--no-verify-ssl` is passes, the SSL warnings are no longer printed
