### PR TITLE
Add option to skip downloading locally existing files

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Options:
   --throw-on-error / --no-throw-on-error
                                   If any project file downloads fails stop
                                   downloading the rest. Default: False
+  --skip-existing / --no-skip-existing
+                                  Skip files if they already exist locally
+                                  with same sha256 hash. Default: False
 ```
 
 #### delete-files

--- a/README.md
+++ b/README.md
@@ -176,9 +176,6 @@ Options:
   --throw-on-error / --no-throw-on-error
                                   If any project file downloads fails stop
                                   downloading the rest. Default: False
-  --skip-existing / --no-skip-existing
-                                  Skip files if they already exist locally
-                                  with same sha256 hash. Default: False
 ```
 
 #### delete-files

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -293,14 +293,18 @@ def upload_files(ctx, project_id, project_path, filter_glob, throw_on_error):
     "--throw-on-error/--no-throw-on-error",
     help="If any project file downloads fails stop downloading the rest. Default: False",
 )
+@click.option(
+    "--skip-existing/--no-skip-existing",
+    help="Skip files if they already exist locally with same sha256 hash. Default: False",
+)
 @click.pass_context
-def download_files(ctx, project_id, local_dir, filter_glob, throw_on_error):
+def download_files(ctx, project_id, local_dir, filter_glob, throw_on_error, skip_existing):
     """Download QFieldCloud project files."""
 
     log(f'Downloading project "{project_id}" files to {local_dir}…')
 
     files = ctx.obj["client"].download_project(
-        project_id, local_dir, filter_glob, throw_on_error, show_progress=True
+        project_id, local_dir, filter_glob, throw_on_error, skip_existing, show_progress=True,
     )
 
     if ctx.obj["format_json"]:

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -293,18 +293,14 @@ def upload_files(ctx, project_id, project_path, filter_glob, throw_on_error):
     "--throw-on-error/--no-throw-on-error",
     help="If any project file downloads fails stop downloading the rest. Default: False",
 )
-@click.option(
-    "--skip-existing/--no-skip-existing",
-    help="Skip files if they already exist locally with same sha256 hash. Default: False",
-)
 @click.pass_context
-def download_files(ctx, project_id, local_dir, filter_glob, throw_on_error, skip_existing):
+def download_files(ctx, project_id, local_dir, filter_glob, throw_on_error):
     """Download QFieldCloud project files."""
 
     log(f'Downloading project "{project_id}" files to {local_dir}…')
 
     files = ctx.obj["client"].download_project(
-        project_id, local_dir, filter_glob, throw_on_error, skip_existing, show_progress=True,
+        project_id, local_dir, filter_glob, throw_on_error, show_progress=True
     )
 
     if ctx.obj["format_json"]:

--- a/src/bin/qfieldcloud-cli
+++ b/src/bin/qfieldcloud-cli
@@ -293,14 +293,18 @@ def upload_files(ctx, project_id, project_path, filter_glob, throw_on_error):
     "--throw-on-error/--no-throw-on-error",
     help="If any project file downloads fails stop downloading the rest. Default: False",
 )
+@click.option(
+    "--force-download/--no-force-download",
+    help="Download file even if it already exists locally. Default: False",
+)
 @click.pass_context
-def download_files(ctx, project_id, local_dir, filter_glob, throw_on_error):
+def download_files(ctx, project_id, local_dir, filter_glob, throw_on_error, force_download):
     """Download QFieldCloud project files."""
 
     log(f'Downloading project "{project_id}" files to {local_dir}…')
 
     files = ctx.obj["client"].download_project(
-        project_id, local_dir, filter_glob, throw_on_error, show_progress=True
+        project_id, local_dir, filter_glob, throw_on_error, show_progress=True, force_download=force_download,
     )
 
     if ctx.obj["format_json"]:
@@ -441,14 +445,18 @@ def package_latest(ctx, project_id):
     "--throw-on-error/--no-throw-on-error",
     help="If any packaged file downloads fails stop downloading the rest. Default: False",
 )
+@click.option(
+    "--force-download/--no-force-download",
+    help="Download file even if it already exists locally. Default: False",
+)
 @click.pass_context
-def package_download(ctx, project_id, local_dir, filter_glob, throw_on_error):
+def package_download(ctx, project_id, local_dir, filter_glob, throw_on_error, force_download):
     """Download packaged QFieldCloud project files."""
 
     log(f'Downloading the latest project "{project_id}" package files to {local_dir}…')
 
     files = ctx.obj["client"].package_download(
-        project_id, local_dir, filter_glob, throw_on_error, show_progress=True
+        project_id, local_dir, filter_glob, throw_on_error, show_progress=True, force_download=force_download,
     )
 
     if ctx.obj["format_json"]:

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -278,7 +278,6 @@ class Client:
         local_dir: str,
         filter_glob: str = None,
         throw_on_error: bool = False,
-        skip_existing: bool = False,
         show_progress: bool = False,
     ) -> List[Dict]:
         """Download the specified project files into the destination dir.
@@ -298,7 +297,6 @@ class Client:
             local_dir,
             filter_glob,
             throw_on_error,
-            skip_existing,
             show_progress,
         )
 
@@ -479,7 +477,6 @@ class Client:
         local_dir: str,
         filter_glob: str = None,
         throw_on_error: bool = False,
-        skip_existing: bool = False,
         show_progress: bool = False,
     ) -> List[Dict]:
         """Download project files.
@@ -492,7 +489,6 @@ class Client:
             filter_glob (str, optional): Download only files matching the glob pattern. If None download all. Defaults to None.
             throw_on_error (bool, optional): Throw if download error occurres. Defaults to False.
             show_progress (bool, optional): Show progress bar in the console. Defaults to False.
-            skip_existing (bool, optional): Skip files if they already exist locally with same sha256 hash. Defaults to False.
 
         Raises:
             QFieldCloudException: if throw_on_error is True, throw an error if a download request fails.
@@ -508,19 +504,6 @@ class Client:
         for file in files:
             if fnmatch.fnmatch(file["name"], filter_glob):
                 file["status"] = FileTransferStatus.PENDING
-
-                local_filename = Path(f'{local_dir}/{file["name"]}')
-                if skip_existing and local_filename.exists():
-
-                    sha256_hash = hashlib.sha256()
-                    with open(local_filename, 'rb') as f:
-                        for byte_block in iter(lambda: f.read(4096), b""):
-                            sha256_hash.update(byte_block)
-
-                    if file['sha256'] == sha256_hash.hexdigest():
-                        logging.info(f'Skip file "{file["name"]}" because it already exists locally')
-                        continue
-
                 files_to_download.append(file)
 
         for file in files_to_download:

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -514,7 +514,7 @@ class Client:
 
                     sha256_hash = hashlib.sha256()
                     with open(local_filename, 'rb') as f:
-                        for byte_block in iter(lambda: f.read(4096),b""):
+                        for byte_block in iter(lambda: f.read(4096), b""):
                             sha256_hash.update(byte_block)
 
                     if file['sha256'] == sha256_hash.hexdigest():

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -278,6 +278,7 @@ class Client:
         local_dir: str,
         filter_glob: str = None,
         throw_on_error: bool = False,
+        skip_existing: bool = False,
         show_progress: bool = False,
     ) -> List[Dict]:
         """Download the specified project files into the destination dir.
@@ -297,6 +298,7 @@ class Client:
             local_dir,
             filter_glob,
             throw_on_error,
+            skip_existing,
             show_progress,
         )
 
@@ -477,6 +479,7 @@ class Client:
         local_dir: str,
         filter_glob: str = None,
         throw_on_error: bool = False,
+        skip_existing: bool = False,
         show_progress: bool = False,
     ) -> List[Dict]:
         """Download project files.
@@ -489,6 +492,7 @@ class Client:
             filter_glob (str, optional): Download only files matching the glob pattern. If None download all. Defaults to None.
             throw_on_error (bool, optional): Throw if download error occurres. Defaults to False.
             show_progress (bool, optional): Show progress bar in the console. Defaults to False.
+            skip_existing (bool, optional): Skip files if they already exist locally with same sha256 hash. Defaults to False.
 
         Raises:
             QFieldCloudException: if throw_on_error is True, throw an error if a download request fails.
@@ -504,6 +508,19 @@ class Client:
         for file in files:
             if fnmatch.fnmatch(file["name"], filter_glob):
                 file["status"] = FileTransferStatus.PENDING
+
+                local_filename = Path(f'{local_dir}/{file["name"]}')
+                if skip_existing and local_filename.exists():
+
+                    sha256_hash = hashlib.sha256()
+                    with open(local_filename, 'rb') as f:
+                        for byte_block in iter(lambda: f.read(4096),b""):
+                            sha256_hash.update(byte_block)
+
+                    if file['sha256'] == sha256_hash.hexdigest():
+                        logging.info(f'Skip file "{file["name"]}" because it already exists locally')
+                        continue
+
                 files_to_download.append(file)
 
         for file in files_to_download:

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -279,6 +279,7 @@ class Client:
         filter_glob: str = None,
         throw_on_error: bool = False,
         show_progress: bool = False,
+        force_download: bool = False,
     ) -> List[Dict]:
         """Download the specified project files into the destination dir.
 
@@ -286,6 +287,7 @@ class Client:
             project_id: id of the project to be downloaded
             local_dir: destination directory where the files will be downloaded
             filter_glob: if specified, download only the files which match the glob, otherwise download all
+            force_download (bool, optional): Download file even if it already exists locally. Defaults to False.
         """
 
         files = self.list_remote_files(project_id)
@@ -298,6 +300,7 @@ class Client:
             filter_glob,
             throw_on_error,
             show_progress,
+            force_download,
         )
 
     def list_jobs(self, project_id: str, job_type: JobTypes = None) -> Dict[str, Any]:
@@ -442,6 +445,7 @@ class Client:
         filter_glob: str = None,
         throw_on_error: bool = False,
         show_progress: bool = False,
+        force_download: bool = False,
     ) -> List[Dict]:
         """Download the specified project packaged files into the destination dir.
 
@@ -449,6 +453,7 @@ class Client:
             project_id: id of the project to be downloaded
             local_dir: destination directory where the files will be downloaded
             filter_glob: if specified, download only packaged files which match the glob, otherwise download all
+            force_download (bool, optional): Download file even if it already exists locally. Defaults to False.
         """
         project_status = self.package_latest(project_id)
 
@@ -467,6 +472,7 @@ class Client:
             filter_glob,
             throw_on_error,
             show_progress,
+            force_download,
         )
 
     def download_files(
@@ -478,6 +484,7 @@ class Client:
         filter_glob: str = None,
         throw_on_error: bool = False,
         show_progress: bool = False,
+        force_download: bool = False,
     ) -> List[Dict]:
         """Download project files.
 
@@ -489,7 +496,7 @@ class Client:
             filter_glob (str, optional): Download only files matching the glob pattern. If None download all. Defaults to None.
             throw_on_error (bool, optional): Throw if download error occurres. Defaults to False.
             show_progress (bool, optional): Show progress bar in the console. Defaults to False.
-
+            force_download (bool, optional): Download file even if it already exists locally. Defaults to False.
         Raises:
             QFieldCloudException: if throw_on_error is True, throw an error if a download request fails.
 
@@ -515,7 +522,9 @@ class Client:
                     download_type,
                     local_filename,
                     file["name"],
+                    file.get("md5sum", None),
                     show_progress,
+                    force_download,
                 )
                 file["status"] = FileTransferStatus.SUCCESS
             except QfcRequestException as err:
@@ -541,7 +550,9 @@ class Client:
         download_type: FileTransferType,
         local_filename: Path,
         remote_filename: Path,
+        remote_md5sum: str,
         show_progress: bool,
+        force_download: bool = False,
     ) -> requests.Response:
         """Download a single project file.
 
@@ -551,6 +562,7 @@ class Client:
             local_filename (Path): Local filename
             remote_filename (Path): Remote filename
             show_progress (bool): Show progressbar in the console
+            force_download (bool, optional): Download file even if it already exists locally. Defaults to False.
 
         Raises:
             NotImplementedError: Raised if unknown `download_type` is passed
@@ -558,6 +570,21 @@ class Client:
         Returns:
             requests.Response: the response object
         """
+
+        if (not force_download) and local_filename.exists() and remote_md5sum:
+            with open(local_filename, "rb") as f:
+                file_hash = hashlib.md5()
+                chunk = f.read(8192)
+                while chunk:
+                    file_hash.update(chunk)
+                    chunk = f.read(8192)
+            if file_hash.hexdigest() == remote_md5sum:
+                if show_progress:
+                    print(f"{remote_filename}: Already present locally. Download skipped.")
+                else:
+                    logging.info(f'Skipping downloading file "{remote_filename}" because it is already present locally')
+                return
+
         if download_type == FileTransferType.PROJECT:
             url = f"files/{project_id}/{remote_filename}"
         elif download_type == FileTransferType.PACKAGE:

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -580,9 +580,13 @@ class Client:
                     chunk = f.read(8192)
             if file_hash.hexdigest() == remote_md5sum:
                 if show_progress:
-                    print(f"{remote_filename}: Already present locally. Download skipped.")
+                    print(
+                        f"{remote_filename}: Already present locally. Download skipped."
+                    )
                 else:
-                    logging.info(f'Skipping downloading file "{remote_filename}" because it is already present locally')
+                    logging.info(
+                        f'Skipping downloading file "{remote_filename}" because it is already present locally'
+                    )
                 return
 
         if download_type == FileTransferType.PROJECT:


### PR DESCRIPTION
Add the option `--skip-existing` to the `download-files` command. If the option is set, it will check the sha256 hash of the local files in the destination directory and avoid downloading remote files if the hash is the same.