### PR TITLE
Skip downloading the S3 metadata if `skip_metadata=1` is passed to the API `/files/` list endpoint

### DIFF
--- a/src/qfieldcloud_sdk/cli.py
+++ b/src/qfieldcloud_sdk/cli.py
@@ -201,13 +201,19 @@ def list_projects(ctx, **opts):
 
 @cli.command()
 @click.argument("project_id")
+@click.option(
+    "--skip-metadata/--no-skip-metadata",
+    "skip_metadata",
+    default=True,
+    help="Skip requesting for additional metadata (currently the `sha256` checksum) for each version. Default: --skip-metadata",
+)
 @click.pass_context
-def list_files(ctx, project_id):
+def list_files(ctx, project_id, skip_metadata):
     """List QFieldCloud project files."""
 
     log(f'Getting file list for "{project_id}"…')
 
-    files = ctx.obj["client"].list_remote_files(project_id)
+    files = ctx.obj["client"].list_remote_files(project_id, skip_metadata)
 
     if ctx.obj["format_json"]:
         print_json(files)

--- a/src/qfieldcloud_sdk/sdk.py
+++ b/src/qfieldcloud_sdk/sdk.py
@@ -138,8 +138,15 @@ class Client:
 
         return resp.json()
 
-    def list_remote_files(self, project_id: str) -> List[Dict[str, Any]]:
-        resp = self._request("GET", f"files/{project_id}")
+    def list_remote_files(
+        self, project_id: str, skip_metadata: bool = True
+    ) -> List[Dict[str, Any]]:
+        params = {}
+
+        if skip_metadata:
+            params["skip_metadata"] = "1"
+
+        resp = self._request("GET", f"files/{project_id}", params=params)
         return resp.json()
 
     def create_project(


### PR DESCRIPTION
The metadata (the field `sha256`) for each file version is not needed,
since the SDK is using a md5 checksum that is provided anyways.