### PR TITLE
Fix types, don't import global Response anymore

### DIFF
--- a/qfieldcloud_sdk/cli.py
+++ b/qfieldcloud_sdk/cli.py
@@ -150,7 +150,7 @@ def logout(ctx):
 
 @cli.command()
 @click.option(
-    "-off",
+    "-o",
     "--offset",
     type=int,
     default=None,
@@ -382,7 +382,7 @@ def delete_files(ctx, project_id, paths, throw_on_error):
     help="Job type. One of package, delta_apply or process_projectfile.",
 )
 @click.option(
-    "-off",
+    "-o",
     "--offset",
     type=int,
     default=None,

--- a/qfieldcloud_sdk/sdk.py
+++ b/qfieldcloud_sdk/sdk.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, List, Optional
 
 import requests
 import urllib3
-from requests.models import Response
 
 from qfieldcloud_sdk.interfaces import QfcException, QfcRequest, QfcRequestException
 from qfieldcloud_sdk.utils import get_numeric_params, log
@@ -744,7 +743,9 @@ class Client:
         return response
 
     @staticmethod
-    def _serialize_paginated_results(response: Response) -> List[Dict[str, Any]]:
+    def _serialize_paginated_results(
+        response: requests.Response,
+    ) -> List[Dict[str, Any]]:
         """Serialize results. Notify en passant users if results are paginated."""
         total_count_header = response.headers.get("X-Total-Count")
 


### PR DESCRIPTION
It already used the prefixed `requests` objects, so let's stick to it.

Also, usually the `-` parameters are single letter. While not envorced, it is a common expectation. Especially on linux systems, it looks weird to combine GNU and BSD style.