### PR TITLE
Fix wrong pypi namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
 
 ### Linux/macOS
 
-    pip3 install qfieldcloud-sdk-python
+    pip3 install qfieldcloud-sdk
 
 ### Windows
 
 Install Python with your favorite package manager. Then:
 
-    python -m pip install qfieldcloud-sdk-python
+    python -m pip install qfieldcloud-sdk
 
 ## CLI usage
 


### PR DESCRIPTION
Not sure how it went under (my) radar, sorry about that.
![image](https://github.com/opengisch/qfieldcloud-sdk-python/assets/19554213/3292f896-4de5-4b94-8298-b4abbe2fa4ec)
