### PR TITLE
Fix `QFIELDCLOUD_URL` in cli's help

### DIFF
--- a/qfieldcloud_sdk/cli.py
+++ b/qfieldcloud_sdk/cli.py
@@ -111,7 +111,7 @@ def cli(
 
         Environment variables can be used instead of passing some common global options.
 
-        QFIELDCLOUD_API - QFieldCloud API endpoint URL
+        QFIELDCLOUD_URL - QFieldCloud API endpoint URL
 
         QFIELDCLOUD_USERNAME - QFieldCloud username or email. Requires `QFIELDCLOUD_PASSWORD` to be set.
 


### PR DESCRIPTION
This PR fixes the help command displayed when running `qfieldcloud-cli --help`

Before it was displaying `QFIELDCLOUD_API - QFieldCloud API endpoint URL`, but actually the env variable that is used is `QFIELDCLOUD_URL`