### PR TITLE
Fix URL path handling to add trailing slash conditionally

### DIFF
--- a/qfieldcloud_sdk/sdk.py
+++ b/qfieldcloud_sdk/sdk.py
@@ -1727,7 +1727,7 @@ class Client:
             if path.startswith("/"):
                 path = path[1:]
 
-            if not path.endswith("/"):
+            if not path.endswith("/") and path.find("?") == -1:
                 path += "/"
 
             path = self.url + path


### PR DESCRIPTION
Ensure trailing slash is added only when the path does not contain a query string. This prevents incorrect URL formatting in specific cases involving query parameters.

Note: Important for my client, TotalEnergies
pascal.conrad@pm.me