### PR TITLE
fix: add trailing URL slash so we not break query string in the URL

### DIFF
--- a/qfieldcloud_sdk/sdk.py
+++ b/qfieldcloud_sdk/sdk.py
@@ -13,7 +13,7 @@ import urllib3
 from requests.adapters import HTTPAdapter, Retry
 
 from .interfaces import QfcException, QfcRequest, QfcRequestException
-from .utils import calc_etag, log
+from .utils import calc_etag, log, add_trailing_slash_to_url
 from pathvalidate import is_valid_filepath
 
 
@@ -1727,10 +1727,9 @@ class Client:
             if path.startswith("/"):
                 path = path[1:]
 
-            if not path.endswith("/"):
-                path += "/"
-
             path = self.url + path
+
+        path = add_trailing_slash_to_url(path)
 
         if pagination:
             limit = pagination.limit or DEFAULT_PAGINATION_LIMIT

--- a/qfieldcloud_sdk/utils.py
+++ b/qfieldcloud_sdk/utils.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 from typing import List
+from urllib.parse import urlparse, urlunparse
 
 
 def print_json(data):
@@ -114,3 +115,38 @@ def format_project_table(projects: List) -> str:
         headers=["ID", "OWNER/NAME", "IS PUBLIC", "DESCRIPTION"],
         data=data,
     )
+
+
+def add_trailing_slash_to_url(url: str) -> str:
+    """
+    Add a trailing slash to a URL if it doesn't already have one.
+
+    Args:
+        url (str): The URL to process
+
+    Returns:
+        str: URL with trailing slash added
+
+    Examples:
+        >>> add_trailing_slash("https://example.com")
+        'https://example.com/'
+        >>> add_trailing_slash("https://example.com/")
+        'https://example.com/'
+        >>> add_trailing_slash("https://example.com/path")
+        'https://example.com/path/'
+        >>> add_trailing_slash("https://example.com/file.txt")
+        'https://example.com/file.txt/'
+    """
+    if not url:
+        return url
+
+    parsed = urlparse(url)
+
+    # Add trailing slash to path if it doesn't end with one
+    path = parsed.path
+    if not path.endswith("/"):
+        path += "/"
+
+    # Reconstruct the URL with the modified path
+    modified_parsed = parsed._replace(path=path)
+    return urlunparse(modified_parsed)


### PR DESCRIPTION
Use urlparse to do it properly.

QFieldCloud expects trailing slashes in the resource URLs. We add them in a very naive way now, just checking the string. This causes issues if the URL has querystring, hash or other elements.

Supercedes https://github.com/opengisch/qfieldcloud-sdk-python/pull/82 .