### PR TITLE
Avoid double login for 'login' subcommand in CLI

### DIFF
--- a/qfieldcloud_sdk/cli.py
+++ b/qfieldcloud_sdk/cli.py
@@ -133,7 +133,9 @@ def cli(
     ctx.obj["format_json"] = format_json
 
     if username or password:
-        ctx.obj["client"].login(username, password)
+        # Guard against parent 'pre-login' for login subcommand
+        if ctx.invoked_subcommand != "login":
+            ctx.obj["client"].login(username, password)
 
 
 @cli.command()


### PR DESCRIPTION
Fixes #86

The problem seemed to be that the CLI command `login` attempts a 'pre-login' from the parent CLI command, from the provided flags or env var params.

Click then moves onto the `login` subcommand and runs a login there too - double login.

This caused the secondary problem of not respecting the provided positional or flag args for the `login` command, as prescedence over set environment variables upstream.