### PR TITLE
feat: add multipart encoder when uploading (large) files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ charset-normalizer>=3.2.0
 click>=8.1.5
 idna>=3.4
 requests>=2.31.0
+requests-toolbelt>=1.0.0
 tqdm>=4.65.0
 urllib3>=2.0.7
 pathvalidate>=3.2.1


### PR DESCRIPTION
Also added a bit of typingWith the previous implementation of `upload_files`, the SDK was loading
the whole file to be uploaded in the memory and only then sending it
over the socket. This was painfully slow, memory constrained and lacked
real feedback.

Therefore the `requests_toolbelt`'s `MultipartEncoderMonitor` is
introduced in this PR, which keeps the memory consumption under control.

This is quite useful not only for CLI consumers of the SDK, but also for
QFieldCloud `qgis` workers, as the memory does not grow too much when
uploading large files after `package` or `apply_deltas` job.