### PR TITLE
fix: do not prepare the request twice before sending

### DIFF
--- a/qfieldcloud_sdk/sdk.py
+++ b/qfieldcloud_sdk/sdk.py
@@ -1956,7 +1956,7 @@ class Client:
             )
             settings = settings | session_params  # type: ignore
 
-            response = self.session.send(request.prepare(), **settings)
+            response = self.session.send(prepared_request, **settings)
 
         try:
             response.raise_for_status()


### PR DESCRIPTION
Since we already prepare the request with `prepared_request = self.session.prepare_request(request)`, this PR fixes the 2nd unnecessary request prepare.

Following up #102 