### PR TITLE
chore: drop `skip-metadata` option

### DIFF
--- a/qfieldcloud_sdk/cli.py
+++ b/qfieldcloud_sdk/cli.py
@@ -324,17 +324,11 @@ def get_project_seed_xlsform(
 
 @cli.command()
 @click.argument("project_id")
-@click.option(
-    "--skip-metadata/--no-skip-metadata",
-    "skip_metadata",
-    default=True,
-    help="Skip requesting for additional metadata (currently the `sha256` checksum) for each version. Default: --skip-metadata",
-)
 @click.pass_context
-def list_files(ctx: Context, project_id, skip_metadata):
+def list_files(ctx: Context, project_id):
     """List QFieldCloud project files."""
 
-    files = ctx.obj["client"].list_remote_files(project_id, skip_metadata)
+    files = ctx.obj["client"].list_remote_files(project_id)
 
     if ctx.obj["format_json"]:
         print_json(files)

--- a/qfieldcloud_sdk/sdk.py
+++ b/qfieldcloud_sdk/sdk.py
@@ -523,26 +523,23 @@ class Client:
         return cast(Optional[str], message.get_filename())
 
     def list_remote_files(
-        self, project_id: str, skip_metadata: bool = True
+        self,
+        project_id: str,
     ) -> List[Dict[str, Any]]:
         """List project files.
 
         Args:
             project_id: Project ID.
-            skip_metadata: Whether to skip fetching metadata for the files. Defaults to True.
 
         Returns:
             A list of file details.
 
         Example:
             ```python
-            client.list_remote_files("123e4567-e89b-12d3-a456-426614174000", False)
+            client.list_remote_files("123e4567-e89b-12d3-a456-426614174000")
             ```
         """
-        params = {}
-
-        if skip_metadata:
-            params["skip_metadata"] = "1"
+        params: Dict[str, str] = {}
 
         resp = self._request("GET", f"files/{project_id}", params=params)
         remote_files = resp.json()


### PR DESCRIPTION
This option is not anymore used in recent versions of QFieldCloud.  
See https://github.com/opengisch/QFieldCloud/pull/1593