### PR TITLE
Clean-up the unused dependencies of the SDK

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: GIS",
 ]
 dependencies = [
-    "certifi>=2023.7.22",
-    "charset-normalizer>=3.2.0",
     "click>=8.1.5",
-    "idna>=3.4",
     "requests>=2.31.0",
     "requests-toolbelt>=1.0.0",
     "tqdm>=4.65.0",

--- a/uv.lock
+++ b/uv.lock
@@ -282,6 +282,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -877,11 +878,8 @@ wheels = [
 name = "qfieldcloud-sdk"
 source = { editable = "." }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "click", version = "8.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "idna" },
     { name = "pathvalidate" },
     { name = "requests" },
     { name = "requests-toolbelt" },
@@ -905,11 +903,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "certifi", specifier = ">=2023.7.22" },
-    { name = "charset-normalizer", specifier = ">=3.2.0" },
     { name = "click", specifier = ">=8.1.5" },
     { name = "fancyboxmd", marker = "extra == 'docs'", specifier = "~=1.1" },
-    { name = "idna", specifier = ">=3.4" },
     { name = "mkdocs-click", marker = "extra == 'docs'", specifier = "~=0.8.1" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = "~=9.5.17" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = "~=0.25" },


### PR DESCRIPTION
We quite literally defined every single dependency of the SDK. We don't need this, we can list only the direct dependencies.